### PR TITLE
Fix indentation in sample acrolinx.yaml?

### DIFF
--- a/resources/core-platform/helm/k3s-crd/acrolinx.yaml
+++ b/resources/core-platform/helm/k3s-crd/acrolinx.yaml
@@ -35,8 +35,8 @@ spec:
 
     ### A list of feature flags that should be enabled. Our support staff may ask you to add flags here. Format: "{feature-1,feature-2}"
     platform.features: "{}"
-### Guidance package
-platform.spec.guidance: "standard:43854"
+    ### Guidance package
+    platform.spec.guidance: "standard:43854"
 valuesContent: |-
   platform:
     spec:


### PR DESCRIPTION
* I suppose "platform.spec.guidance" needs to be on the same level as e.g.
  "platform.spec.securityContext.runAsUser"