### PR TITLE
Fixed indentation.

### DIFF
--- a/resources/core-platform/helm/k3s-crd/acrolinx.yaml
+++ b/resources/core-platform/helm/k3s-crd/acrolinx.yaml
@@ -37,26 +37,26 @@ spec:
     platform.features: "{}"
     ### Guidance package
     platform.spec.guidance: "standard:43854"
-valuesContent: |-
-  platform:
-    spec:
-      languageServers:
-        - name: default
-          languages: [ en, de ]
-        #- name: large
-        #  languages: [ en, de ]
-        #  template:
-        #    containers:
-        #      - name: language-server
-        #        resources:
-        #          limits:
-        #            memory: 6Gi
-      configuration:
-        ### Override settings from the `server/bin/coreserver.properties`.
-        coreserver.properties: ""
-    ### Database settings.
-    ### Preconfigured to work with the test database.
-    persistence:
-      ### Set to `true` to install Postgres test databases into the cluster.
-      ### Never set to `true` in a production system!!
-      installTestDB: false
+  valuesContent: |-
+    platform:
+      spec:
+        languageServers:
+          - name: default
+            languages: [ en, de ]
+          #- name: large
+          #  languages: [ en, de ]
+          #  template:
+          #    containers:
+          #      - name: language-server
+          #        resources:
+          #          limits:
+          #            memory: 6Gi
+        configuration:
+          ### Override settings from the `server/bin/coreserver.properties`.
+          coreserver.properties: ""
+      ### Database settings.
+      ### Preconfigured to work with the test database.
+      persistence:
+        ### Set to `true` to install Postgres test databases into the cluster.
+        ### Never set to `true` in a production system!!
+        installTestDB: false


### PR DESCRIPTION
The `valuesContent` must be on the same level as `set`.