### PR TITLE
Keep versioned copy of the `acrolinx.yaml`

### DIFF
--- a/resources/core-platform/helm/chart/README.md
+++ b/resources/core-platform/helm/chart/README.md
@@ -174,7 +174,7 @@ platform:
 
 #### Database Connections
 
-Add the settings for the Target service database to `persistence.credentials`.
+Add the settings for the Targets database to `persistence.credentials`.
 You can configure settings for the [terminology database][acrolinx-docs-term-db-settings], the [reporting database][acrolinx-docs-reporting-db-settings], and the [JReport databases][acrolinx-docs-jreport-db-settings] in the `server/bin/persistence.properties` file in the configuration directory.
 
 If you want to test the Acrolinx Platform without any external databases, remove any `persistence.credentials` and set `installTestDB` to `true`:

--- a/resources/core-platform/helm/chart/docs/2021.05.md
+++ b/resources/core-platform/helm/chart/docs/2021.05.md
@@ -174,7 +174,7 @@ platform:
 
 #### Database Connections
 
-Add the settings for the Target service database to `persistence.credentials`.
+Add the settings for the Targets database to `persistence.credentials`.
 You can configure settings for the [terminology database][acrolinx-docs-term-db-settings], the [reporting database][acrolinx-docs-reporting-db-settings], and the [JReport databases][acrolinx-docs-jreport-db-settings] in the `server/bin/persistence.properties` file in the configuration directory.
 
 If you want to test the Acrolinx Platform without any external databases, remove any `persistence.credentials` and set `installTestDB` to `true`:

--- a/resources/core-platform/helm/k3s-crd/2021.05/acrolinx.yaml
+++ b/resources/core-platform/helm/k3s-crd/2021.05/acrolinx.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acrolinx-system
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: acrolinx
+---
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: acrolinx
+  namespace: acrolinx-system
+spec:
+  repo: https://acrolinx.github.io/helm/
+  chart: acrolinx-platform
+  version: "1.0.5+2021.05"
+  set:
+    ### Guidance package
+    platform.spec.guidance: "standard:43854"
+
+    ### Image download - Enter your credentials for the Acrolinx download area
+    ### to be able to download the container images.
+    images.downloadAreaUser: ""
+    images.downloadAreaPwd: ""
+
+    ### Configuration directory
+    platform.spec.securityContext.runAsUser: 1001
+    platform.spec.securityContext.runAsGroup: 1001
+    platform.spec.coreServer.overlayDirectory.volumeSource.hostPath.path: >
+      /home/acrolinx/config
+
+    ### Name of the secret that contains the TLS certificate.
+    platform.spec.ingress.tlsSecretName: ""
+
+    ### A list of feature flags that should be enabled. Our support staff may ask you to add flags here. Format: "{feature-1,feature-2}"
+    platform.features: "{}"
+  valuesContent: |-
+    platform:
+      spec:
+        languageServers:
+          - name: default
+            languages: [ en, de ]
+          #- name: large
+          #  languages: [ en, de ]
+          #  template:
+          #    containers:
+          #      - name: language-server
+          #        resources:
+          #          limits:
+          #            memory: 6Gi
+        configuration:
+          ### Override settings from the `server/bin/coreserver.properties`.
+          coreserver.properties: ""
+      ### Database settings.
+      ### Preconfigured to work with the test database.
+      persistence:
+        ### Set to `true` to install Postgres test databases into the cluster.
+        ### Never set to `true` in a production system!!
+        installTestDB: false


### PR DESCRIPTION
Our platform docuementation is versioned, hence links in it must point to the correct version of the `acrolinx.yaml` file. 
As a precondition we must have such a copy with the version in the URL in the first place.

Also updated a wording based on a terminology change.